### PR TITLE
Add global auth middleware

### DIFF
--- a/src/lib/profileContext.ts
+++ b/src/lib/profileContext.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+
+export interface ProfileContext {
+  profileId: number;
+  nickName: string;
+  [key: string]: any;
+}
+
+export function getProfileFromRequestContext(
+  req: NextRequest
+): ProfileContext | null {
+  const profileString = req.headers.get("x-user-profile");
+  if (!profileString) return null;
+
+  try {
+    return JSON.parse(profileString);
+  } catch (err) {
+    console.error("프로필 파싱 실패:", err);
+    return null;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyJwt } from "@/lib/verifyJwt";
+import { prisma } from "@/lib/prisma";
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  // 인증이 필요 없는 경로는 통과
+  if (pathname.startsWith("/api/auth")) {
+    return NextResponse.next();
+  }
+
+  const token = req.cookies.get("token")?.value;
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = verifyJwt(token);
+  if (!payload?.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const profile = await prisma.profile.findFirst({
+    where: { userId: payload.userId },
+  });
+
+  if (!profile) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-user-profile", JSON.stringify(profile));
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/api/:path*"],
+};


### PR DESCRIPTION
## Summary
- implement middleware to attach verified profile info to API requests
- add helper to extract profile data from request context

## Testing
- `npm run lint` *(fails: next not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6889e8b9741c832184c40fee12df675d