### PR TITLE
Fix JWT verification in edge runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "embla-carousel-react": "^8.6.0",
     "formidable": "^3.5.4",
     "jsonwebtoken": "^9.0.2",
+    "jose": "^5.2.0",
     "libphonenumber-js": "^1.12.10",
     "next": "15.3.3",
     "next-auth": "^5.0.0-beta.28",

--- a/src/app/api/boards/[boardId]/posts/route.ts
+++ b/src/app/api/boards/[boardId]/posts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getProfileFromToken } from "@/lib/getProfile";
+import { getProfileFromRequest } from "@/lib/getProfile";
 
 // 첨부파일 타입 정의
 interface Attachment {
@@ -65,29 +65,11 @@ export async function POST(
 ) {
   try {
     // 인증 확인
-    const token = req.headers.get("x-access-token");
-    if (!token) {
-      return NextResponse.json(
-        { error: "인증이 필요합니다." },
-        { status: 401 }
-      );
-    }
-
-    const payload = getProfileFromToken(token);
-    if (!payload?.userId) {
-      return NextResponse.json(
-        { error: "토큰이 유효하지 않습니다." },
-        { status: 401 }
-      );
-    }
-
-    const profile = await prisma.profile.findFirst({
-      where: { userId: payload.userId },
-    });
+    const profile = await getProfileFromRequest(req);
 
     if (!profile) {
       return NextResponse.json(
-        { error: "프로필을 찾을 수 없습니다." },
+        { message: '인증되지 않았거나 프로필을 찾을 수 없습니다.' },
         { status: 401 }
       );
     }

--- a/src/lib/verifyJwt.ts
+++ b/src/lib/verifyJwt.ts
@@ -1,6 +1,8 @@
-import jwt from "jsonwebtoken";
+import { jwtVerify } from "jose";
 
-const JWT_SECRET = process.env.JWT_SECRET || "your-default-secret-key"; // 꼭 환경변수로 설정하세요!
+const JWT_SECRET = new TextEncoder().encode(
+  process.env.JWT_SECRET || "your-default-secret-key"
+); // 꼭 환경변수로 설정하세요!
 
 interface JwtPayload {
   userId: number;
@@ -8,10 +10,10 @@ interface JwtPayload {
   exp?: number;
 }
 
-export function verifyJwt(token: string): JwtPayload | null {
+export async function verifyJwt(token: string): Promise<JwtPayload | null> {
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload;
-    return decoded;
+    const { payload } = await jwtVerify(token, JWT_SECRET);
+    return payload as JwtPayload;
   } catch (error) {
     console.error("JWT 검증 실패:", error);
     return null;


### PR DESCRIPTION
## Summary
- add jose dependency
- verify JWTs with `jose` for edge compatibility
- restore middleware verification and header format
- update signin API to sign tokens with `jose`
- adjust board post API to use profile from middleware

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f0fa7b308321a2658f4db5524ae1