### PR TITLE
feat: add AI interview interface

### DIFF
--- a/src/app/api/AIInterview/[sessionId]/record/route.ts
+++ b/src/app/api/AIInterview/[sessionId]/record/route.ts
@@ -66,11 +66,9 @@ export async function POST(
       { ...data, transcribedText: text },
       { status: res.status }
     );
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("record 에러:", error);
-    return NextResponse.json(
-      { error: error.message ?? "알 수 없는 오류" },
-      { status: 500 }
-    );
+    const message = error instanceof Error ? error.message : "알 수 없는 오류";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/interview/ai/page.tsx
+++ b/src/app/interview/ai/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import Navbar from "@/components/Navbar";
+import Recorder from "@/components/interview/Recorder";
+
+interface Message {
+  role: "assistant" | "user";
+  content: string;
+}
+
+export default function AIInterviewPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [sessionId, setSessionId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const startSession = async () => {
+    try {
+      setLoading(true);
+      const res = await fetch("/api/AIInterview/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ persona: "기본 면접관" }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setSessionId(data.sessionId);
+        setMessages([{ role: "assistant", content: data.question }]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAudioComplete = async (audio: Blob) => {
+    if (!sessionId) return;
+    const form = new FormData();
+    form.append("file", audio, "audio.webm");
+    const res = await fetch(`/api/AIInterview/${sessionId}/record`, {
+      method: "POST",
+      body: form,
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setMessages((prev) => [
+        ...prev,
+        { role: "user", content: data.transcribedText },
+        { role: "assistant", content: data.question },
+      ]);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--gray-50)]">
+      <Navbar />
+      <div className="flex h-[calc(100vh-4rem)] pt-16">
+        <div className="flex flex-col flex-1 max-w-3xl mx-auto w-full">
+          <div className="flex-1 overflow-y-auto p-4">
+            {messages.length === 0 ? (
+              <div className="h-full flex items-center justify-center">
+                <button
+                  onClick={startSession}
+                  disabled={loading}
+                  className="px-6 py-3 bg-[var(--primary)] text-white rounded-lg shadow-md hover:bg-[var(--primary-hover)] disabled:opacity-50"
+                >
+                  {loading ? "시작중..." : "새 면접 시작하기"}
+                </button>
+              </div>
+            ) : (
+              messages.map((m, i) => (
+                <div
+                  key={i}
+                  className={`mb-4 flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
+                >
+                  <div
+                    className={`px-4 py-2 rounded-2xl max-w-[75%] shadow ${
+                      m.role === "user"
+                        ? "bg-[var(--primary)] text-white"
+                        : "bg-white border"
+                    }`}
+                  >
+                    {m.content}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+          {sessionId && (
+            <div className="p-4 border-t bg-white flex justify-center">
+              <Recorder onComplete={handleAudioComplete} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -2,25 +2,29 @@
 "use client";
 
 import Link from "next/link";
+import Navbar from "@/components/Navbar";
 
 export default function InterviewHomePage() {
   return (
-    <div className="max-w-4xl mx-auto mt-10 px-4">
-      <h1 className="text-2xl font-bold mb-6">면접 준비</h1>
+    <div className="min-h-screen bg-[var(--gray-50)]">
+      <Navbar />
+      <div className="max-w-4xl mx-auto pt-20 px-4">
+        <h1 className="text-2xl font-bold mb-6">면접 준비</h1>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        {/* AI 면접 */}
-        <Link href="/interview/ai">
-          <div className="border rounded-2xl p-6 hover:shadow-md transition cursor-pointer bg-white">
-            <h2 className="text-xl font-semibold mb-2">AI 면접 시작하기</h2>
-            <p className="text-gray-600">AI가 면접관이 되어 질문을 던지고 피드백을 제공합니다.</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          {/* AI 면접 */}
+          <Link href="/interview/ai">
+            <div className="border rounded-2xl p-6 hover:shadow-md transition cursor-pointer bg-white">
+              <h2 className="text-xl font-semibold mb-2">AI 면접 시작하기</h2>
+              <p className="text-gray-600">AI가 면접관이 되어 질문을 던지고 피드백을 제공합니다.</p>
+            </div>
+          </Link>
+
+          {/* 화상 면접 - 비활성화 */}
+          <div className="border rounded-2xl p-6 bg-gray-100 text-gray-400 cursor-not-allowed">
+            <h2 className="text-xl font-semibold mb-2">사람과 화상 면접</h2>
+            <p className="text-gray-500">곧 제공될 예정입니다.</p>
           </div>
-        </Link>
-
-        {/* 화상 면접 - 비활성화 */}
-        <div className="border rounded-2xl p-6 bg-gray-100 text-gray-400 cursor-not-allowed">
-          <h2 className="text-xl font-semibold mb-2">사람과 화상 면접</h2>
-          <p className="text-gray-500">곧 제공될 예정입니다.</p>
         </div>
       </div>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -123,12 +123,12 @@ export default function Navbar() {
             >
               커뮤니티
             </Link>
-            <a
-              href='#'
+            <Link
+              href='/interview'
               className='text-base font-medium text-[var(--text-secondary)] px-2 py-1 rounded hover:bg-[var(--gray-100)] hover:text-[var(--text-accent)] transition-colors focus:outline-none'
             >
               면접 준비
-            </a>
+            </Link>
           </div>
         </div>
 

--- a/src/components/interview/Recorder.tsx
+++ b/src/components/interview/Recorder.tsx
@@ -2,8 +2,13 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { FaMicrophone, FaStop } from "react-icons/fa";
 
-export default function Recorder({ onComplete }: { onComplete: (audioBlob: Blob) => void }) {
+export default function Recorder({
+  onComplete,
+}: {
+  onComplete: (audioBlob: Blob) => void;
+}) {
   const [recording, setRecording] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunks = useRef<Blob[]>([]);
@@ -35,9 +40,10 @@ export default function Recorder({ onComplete }: { onComplete: (audioBlob: Blob)
   return (
     <button
       onClick={toggleRecording}
-      className={`rounded-full px-4 py-2 mt-4 ${recording ? "bg-red-500" : "bg-blue-500"} text-white`}
+      className={`mt-4 w-12 h-12 rounded-full flex items-center justify-center text-white shadow-md focus:outline-none ${recording ? "bg-red-500" : "bg-[var(--primary)]"}`}
+      aria-label={recording ? "녹음 중지" : "녹음 시작"}
     >
-      {recording ? "녹음 중지" : "녹음 시작"}
+      {recording ? <FaStop /> : <FaMicrophone />}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- add interview prep landing page with navigation
- build ChatGPT-style AI interview page with voice recording
- enhance audio recording component and backend error handling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68942a4d7f508321aae247235f09a799