### PR TITLE
Show transcript immediately and restore login redirect

### DIFF
--- a/src/app/api/AIInterview/[sessionId]/record/route.ts
+++ b/src/app/api/AIInterview/[sessionId]/record/route.ts
@@ -32,12 +32,8 @@ async function transcribeAudio(file: Blob): Promise<string> {
   return text.trim();
 }
 
-export async function POST(
-  req: NextRequest,
-  context: { params: Promise<{ sessionId: string }> }
-) {
+export async function POST(req: NextRequest) {
   try {
-    const { sessionId } = await context.params;
     const formData = await req.formData();
     const audio = formData.get("file") as Blob | null;
 
@@ -50,38 +46,8 @@ export async function POST(
 
     const text = await transcribeAudio(audio);
 
-    // 답변 저장 후 다음 질문 생성
-    const answerRes = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/AIInterview/${sessionId}/answer`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ answerText: text }),
-      }
-    );
-
-    if (!answerRes.ok) {
-      const err = await answerRes.json();
-      return NextResponse.json(err, { status: answerRes.status });
-    }
-
-    const questionRes = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/AIInterview/${sessionId}/question`,
-      { method: "POST" }
-    );
-
-    if (!questionRes.ok) {
-      const err = await questionRes.json();
-      return NextResponse.json(err, { status: questionRes.status });
-    }
-
-    const answerData = await answerRes.json();
-    const questionData = await questionRes.json();
-
-    return NextResponse.json(
-      { ...answerData, question: questionData.question, transcribedText: text },
-      { status: 200 }
-    );
+    // 전사된 텍스트만 반환하고 답변 저장과 다음 질문 생성은 클라이언트에서 처리
+    return NextResponse.json({ transcribedText: text }, { status: 200 });
   } catch (error: unknown) {
     console.error("record 에러:", error);
     const message = error instanceof Error ? error.message : "알 수 없는 오류";

--- a/src/app/interview/ai/page.tsx
+++ b/src/app/interview/ai/page.tsx
@@ -126,6 +126,7 @@ export default function AIInterviewPage() {
       });
       const data = await res.json();
       if (res.ok) {
+        // 먼저 전사된 텍스트를 바로 표시
         setRecords((prev) => {
           const updated = [...prev];
           const lastIndex = updated.length - 1;
@@ -133,18 +134,53 @@ export default function AIInterviewPage() {
             updated[lastIndex] = {
               ...updated[lastIndex],
               answerText: data.transcribedText,
-              summary: data.summary,
-              feedback: data.feedback,
             };
           }
-          updated.push({ question: data.question });
           return updated;
         });
         setMessages((prev) => [
           ...prev,
           { role: "user", content: data.transcribedText },
-          { role: "assistant", content: data.question },
         ]);
+
+        // 답변 저장 및 피드백 생성
+        const answerRes = await fetch(`/api/AIInterview/${sessionId}/answer`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ answerText: data.transcribedText }),
+        });
+        const answerData = await answerRes.json();
+        if (answerRes.ok) {
+          setRecords((prev) => {
+            const updated = [...prev];
+            const lastIndex = updated.length - 1;
+            if (lastIndex >= 0) {
+              updated[lastIndex] = {
+                ...updated[lastIndex],
+                summary: answerData.summary,
+                feedback: answerData.feedback,
+              };
+            }
+            return updated;
+          });
+        }
+
+        // 다음 질문 생성
+        const questionRes = await fetch(`/api/AIInterview/${sessionId}/question`, {
+          method: "POST",
+        });
+        const questionData = await questionRes.json();
+        if (questionRes.ok) {
+          setRecords((prev) => {
+            const updated = [...prev];
+            updated.push({ question: questionData.question });
+            return updated;
+          });
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", content: questionData.question },
+          ]);
+        }
       }
     } finally {
       setProcessing(false);

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,24 +1,32 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { signIn } from 'next-auth/react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Navbar from '@/components/Navbar';
 import ContainerX from '@/components/ContainerX';
 import { signinSchema, type SigninFormData } from '@/lib/schemas/auth';
 import { authAPI, ApiError } from '@/lib/api';
-import { redirectAfterLogin } from '@/lib/redirect';
+import { redirectAfterLogin, setRedirectUrl } from '@/lib/redirect';
 
 export default function SignInPage() {
   const handleGoogleSignIn = () => {
     signIn('google', { callbackUrl: '/' });
   };
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
+
+  useEffect(() => {
+    const redirect = searchParams.get('redirect');
+    if (redirect) {
+      setRedirectUrl(redirect);
+    }
+  }, [searchParams]);
 
   // React Hook Form 설정
   const {


### PR DESCRIPTION
## Summary
- Display user's transcribed answer immediately before generating the next question
- Save interview answers and fetch feedback/questions sequentially on the client
- Preserve original destination by storing redirect query and using it after login

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d1fbe358832187548096ab5e4ee2