### PR TITLE
feat: switch to local whisper transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Local Whisper transcription service
+
+The interview recording API uses a local [Whisper](https://github.com/openai/whisper) service for speech‑to‑text. To run the service:
+
+```bash
+cd whisper_service
+pip install -r requirements.txt
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+Optionally set the `WHISPER_URL` environment variable if the service runs on a different address.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/whisper_service/main.py
+++ b/whisper_service/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import JSONResponse
+import tempfile
+import whisper
+
+app = FastAPI()
+model = whisper.load_model("base")
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile = File(...)):
+    audio_bytes = await file.read()
+    with tempfile.NamedTemporaryFile(suffix=".webm") as tmp:
+        tmp.write(audio_bytes)
+        tmp.flush()
+        result = model.transcribe(tmp.name, language="ko")
+    return JSONResponse({"text": result["text"].strip()})

--- a/whisper_service/requirements.txt
+++ b/whisper_service/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+openai-whisper


### PR DESCRIPTION
## Summary
- replace Gemini speech-to-text with call to a local Whisper service
- add FastAPI-based Whisper microservice and its dependencies
- document how to run the Whisper service and configure its URL

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6895de98a52c832197402ff3b7243132