### PR TITLE
feat: add persona creation and storage

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model Profile {
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?
+  persona   Json?
   comments  Comment[]
   posts     Post[]
   user      User      @relation(fields: [userId], references: [userId])
@@ -133,8 +134,7 @@ model Attachment {
 
 model MockInterviewSession {
   sessionId  Int                    @id @default(autoincrement())
-  profileId  Int                   
-  persona    Json
+  profileId  Int
   records    MockInterviewRecord[]
   summary      String?
   feedback     String?

--- a/src/app/api/AIInterview/end/route.ts
+++ b/src/app/api/AIInterview/end/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { generateSessionSummary } from "@/lib/interview/generateSessionSummary";
+import {
+  generateSessionSummary,
+  Persona,
+} from "@/lib/interview/generateSessionSummary";
 import { getProfileFromRequest } from "@/lib/getProfile";
 
 export async function POST(req: NextRequest) {
@@ -32,8 +35,15 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (!profile.persona) {
+      return NextResponse.json(
+        { error: "페르소나가 설정되지 않았습니다." },
+        { status: 400 }
+      );
+    }
+
     const { summary, feedback } = await generateSessionSummary(
-      session.persona,
+      profile.persona as Persona,
       session.records
     );
 

--- a/src/app/api/AIInterview/start/route.ts
+++ b/src/app/api/AIInterview/start/route.ts
@@ -11,11 +11,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { persona } = await req.json();
-
-    if (!persona) {
+    if (!profile.persona) {
       return NextResponse.json(
-        { error: "persona는 필수입니다." },
+        { error: "페르소나가 설정되지 않았습니다." },
         { status: 400 }
       );
     }
@@ -23,7 +21,6 @@ export async function POST(req: NextRequest) {
     const session = await prisma.mockInterviewSession.create({
       data: {
         profileId: profile.profileId,
-        persona,
       },
     });
 

--- a/src/app/api/persona/route.ts
+++ b/src/app/api/persona/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getProfileFromRequest } from "@/lib/getProfile";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const profile = await getProfileFromRequest(req);
+  if (!profile) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return NextResponse.json(profile.persona ?? null);
+}
+
+export async function POST(req: NextRequest) {
+  const profile = await getProfileFromRequest(req);
+  if (!profile) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const persona = await req.json();
+  const updated = await prisma.profile.update({
+    where: { profileId: profile.profileId },
+    data: { persona },
+  });
+  return NextResponse.json(updated.persona);
+}

--- a/src/app/interview/ai/page.tsx
+++ b/src/app/interview/ai/page.tsx
@@ -50,8 +50,6 @@ export default function AIInterviewPage() {
       setStarting(true);
       const res = await fetch("/api/AIInterview/start", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ persona: "기본 면접관" }),
       });
       const data = await res.json();
       if (res.ok) {

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -3,13 +3,127 @@
 
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
+import { useState, useEffect, ChangeEvent } from "react";
+
+interface PersonaForm {
+  company: string;
+  job: string;
+  careerLevel: string;
+  difficulty: "쉬움" | "중간" | "어려움";
+  techStack: string;
+}
 
 export default function InterviewHomePage() {
+  const [persona, setPersona] = useState<PersonaForm>({
+    company: "",
+    job: "",
+    careerLevel: "",
+    difficulty: "쉬움",
+    techStack: "",
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch("/api/persona");
+      if (res.ok) {
+        const data = await res.json();
+        if (data) {
+          setPersona({
+            company: data.company ?? "",
+            job: data.job ?? "",
+            careerLevel: data.careerLevel ?? "",
+            difficulty: data.difficulty ?? "쉬움",
+            techStack: (data.techStack ?? []).join(", "),
+          });
+        }
+      }
+    };
+    load();
+  }, []);
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setPersona((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const savePersona = async () => {
+    setSaving(true);
+    await fetch("/api/persona", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        company: persona.company,
+        job: persona.job,
+        careerLevel: persona.careerLevel,
+        difficulty: persona.difficulty,
+        techStack: persona.techStack
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      }),
+    });
+    setSaving(false);
+  };
+
   return (
     <div className="min-h-screen bg-[var(--gray-50)]">
       <Navbar />
       <div className="max-w-4xl mx-auto pt-20 px-4">
-        <h1 className="text-2xl font-bold mb-6">면접 준비</h1>
+      <h1 className="text-2xl font-bold mb-6">면접 준비</h1>
+
+        <div className="mb-10 bg-white p-6 rounded-2xl">
+          <h2 className="text-xl font-semibold mb-4">면접 페르소나 설정</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <input
+              name="company"
+              value={persona.company}
+              onChange={handleChange}
+              placeholder="회사"
+              className="border p-2 rounded"
+            />
+            <input
+              name="job"
+              value={persona.job}
+              onChange={handleChange}
+              placeholder="직무"
+              className="border p-2 rounded"
+            />
+            <input
+              name="careerLevel"
+              value={persona.careerLevel}
+              onChange={handleChange}
+              placeholder="경력 수준"
+              className="border p-2 rounded"
+            />
+            <select
+              name="difficulty"
+              value={persona.difficulty}
+              onChange={handleChange}
+              className="border p-2 rounded"
+            >
+              <option value="쉬움">쉬움</option>
+              <option value="중간">중간</option>
+              <option value="어려움">어려움</option>
+            </select>
+            <input
+              name="techStack"
+              value={persona.techStack}
+              onChange={handleChange}
+              placeholder="기술 스택 (콤마로 구분)"
+              className="border p-2 rounded md:col-span-2"
+            />
+          </div>
+          <button
+            onClick={savePersona}
+            disabled={saving}
+            className="mt-4 px-4 py-2 bg-[var(--primary)] text-white rounded-lg disabled:opacity-50"
+          >
+            저장
+          </button>
+        </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           {/* AI 면접 */}

--- a/src/lib/interview/generateQuestion.ts
+++ b/src/lib/interview/generateQuestion.ts
@@ -12,11 +12,15 @@ export async function generateQuestion(sessionId: number): Promise<string> {
   // 2. 페르소나 정보 조회
   const session = await prisma.mockInterviewSession.findUnique({
     where: { sessionId },
+    include: { profile: true },
   });
 
-  if (!session) throw new Error("해당 세션을 찾을 수 없습니다.");
+  if (!session || !session.profile.persona)
+    throw new Error("페르소나가 설정되지 않았습니다.");
 
-  const persona = session.persona;
+  const rawPersona = session.profile.persona;
+  const persona =
+    typeof rawPersona === "string" ? rawPersona : JSON.stringify(rawPersona);
   // 3. 질문/답변 이력 정리
   const historyText = records
     .map((r, i) => `질문 ${i + 1}: ${r.question}\n답변: ${r.answerText}`)

--- a/src/lib/interview/generateSessionSummary.ts
+++ b/src/lib/interview/generateSessionSummary.ts
@@ -1,7 +1,7 @@
 import { genAI } from "@/lib/gemini";
 
 // Persona 타입 정의
-type Persona = {
+export type Persona = {
   company: string;
   job: string;
   careerLevel: string;


### PR DESCRIPTION
## Summary
- allow users to configure a persona from the interview prep page
- store persona on the profile and use it when starting or summarizing interview sessions
- expose API endpoints for reading and updating the persona

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c80c952e4832194bd92fc95a0eb5e