### PR TITLE
feat: add ElevenLabs TTS for interview questions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# API key for ElevenLabs text-to-speech service
+ELEVENLABS_API_KEY=
+# Optional voice ID (defaults to a generic voice)
+ELEVENLABS_VOICE_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
 
+## Text-to-Speech
+
+This project can read interview questions aloud using the free [ElevenLabs](https://elevenlabs.io) API. To enable it, provide the following environment variables:
+
+```
+ELEVENLABS_API_KEY=your_api_key
+ELEVENLABS_VOICE_ID=optional_voice_id
+```
+
+Add these to your `.env.local` file during development or set them in your deployment environment. If they are not set, the application falls back to the browser's built-in `speechSynthesis` API.
+
+
 ```
 vocai-app
 ├─ eslint.config.mjs

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { text } = await req.json();
+    const apiKey = process.env.ELEVENLABS_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: "Missing TTS API key" }, { status: 500 });
+    }
+    const voiceId = process.env.ELEVENLABS_VOICE_ID || "21m00Tcm4TlvDq8ikWAM";
+    const ttsRes = await fetch(
+      `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
+      {
+        method: "POST",
+        headers: {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ text }),
+      }
+    );
+    if (!ttsRes.ok) {
+      const errorText = await ttsRes.text();
+      console.error("TTS request failed", errorText);
+      return NextResponse.json({ error: "TTS request failed" }, { status: 500 });
+    }
+    const audioBuffer = await ttsRes.arrayBuffer();
+    return new Response(audioBuffer, {
+      headers: { "Content-Type": "audio/mpeg" },
+    });
+  } catch (error) {
+    console.error("TTS route error", error);
+    return NextResponse.json({ error: "TTS route error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- integrate ElevenLabs text-to-speech API via new `/api/tts` route
- use external TTS with fallback to `speechSynthesis` in AI interview page
- document ElevenLabs setup with `.env.example` and README updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2c49ff904832181a4d80d3dd72ed2