### PR TITLE
feat: pre-generate interview questions

### DIFF
--- a/src/app/api/AIInterview/[sessionId]/question/route.ts
+++ b/src/app/api/AIInterview/[sessionId]/question/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { generateQuestion } from "@/lib/interview/generateQuestion";
+import { generateSecondQuestion } from "@/lib/interview/generateSecondQuestion";
+import {
+  getCachedQuestion,
+  setCachedQuestion,
+  clearCachedQuestion,
+} from "@/lib/interview/questionCache";
 
 export async function POST(
   req: NextRequest,
@@ -14,7 +20,23 @@ export async function POST(
       return NextResponse.json({ error: "sessionId 오류" }, { status: 400 });
     }
 
-    const question = await generateQuestion(numSessionId);
+    // 캐시에 미리 생성된 질문이 있는지 확인
+    let question = getCachedQuestion(numSessionId);
+    if (question) {
+      clearCachedQuestion(numSessionId);
+    } else {
+      // 답변이 완료된 기록 수 확인
+      const answeredCount = await prisma.mockInterviewRecord.count({
+        where: { sessionId: numSessionId, answerText: { not: null } },
+      });
+
+      if (answeredCount === 1) {
+        // 두 번째 질문은 사전 정의된 후보 중 선택
+        question = await generateSecondQuestion(numSessionId);
+      } else {
+        question = await generateQuestion(numSessionId);
+      }
+    }
 
     const record = await prisma.mockInterviewRecord.create({
       data: {
@@ -25,6 +47,16 @@ export async function POST(
         feedback: null,
       },
     });
+
+    // 다음 질문을 미리 생성하여 캐시에 저장
+    (async () => {
+      try {
+        const next = await generateQuestion(numSessionId);
+        setCachedQuestion(numSessionId, next);
+      } catch (e) {
+        console.error("pre-generate question error", e);
+      }
+    })();
 
     return NextResponse.json({ question, recordId: record.interviewId });
   } catch (error: unknown) {

--- a/src/app/api/AIInterview/start/route.ts
+++ b/src/app/api/AIInterview/start/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getProfileFromRequest } from "@/lib/getProfile";
-import { generateQuestion } from "@/lib/interview/generateQuestion";
 
 export async function POST(req: NextRequest) {
   try {
@@ -30,7 +29,8 @@ export async function POST(req: NextRequest) {
       data: { title: `세션${session.sessionId}` },
     });
 
-    const question = await generateQuestion(session.sessionId);
+    // 첫 질문은 고정: 자기소개 요청
+    const question = "자기소개 부탁드립니다.";
 
     // 첫 질문 저장 (answerText는 null)
     await prisma.mockInterviewRecord.create({
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
         question,
       },
     });
-    
+
     return NextResponse.json(
       { sessionId: session.sessionId, question },
       { status: 201 }

--- a/src/lib/interview/generateQuestion.ts
+++ b/src/lib/interview/generateQuestion.ts
@@ -3,9 +3,9 @@ import { genAI } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
 
 export async function generateQuestion(sessionId: number): Promise<string> {
-  // 1. 이전 질문/답변 기록
+  // 1. 이전 질문/답변 기록 (답변이 완료된 것만)
   const records = await prisma.mockInterviewRecord.findMany({
-    where: { sessionId },
+    where: { sessionId, answerText: { not: null } },
     orderBy: { createdAt: "asc" },
   });
 

--- a/src/lib/interview/generateSecondQuestion.ts
+++ b/src/lib/interview/generateSecondQuestion.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/lib/prisma";
+import { genAI } from "@/lib/gemini";
+
+const candidates = [
+  "지원 동기는 무엇인가요?",
+  "본인의 강점과 약점은 무엇인가요?",
+  "최근 도전 과제와 해결 방법은 무엇인가요?",
+];
+
+export async function generateSecondQuestion(sessionId: number): Promise<string> {
+  const firstRecord = await prisma.mockInterviewRecord.findFirst({
+    where: { sessionId },
+    orderBy: { createdAt: "asc" },
+  });
+  const answer = firstRecord?.answerText ?? "";
+
+  const prompt = `지원자의 자기소개 답변:\n"""${answer}"""\n\n위 답변을 참고하여 아래 후보 질문 중 아직 답하지 않은 주제를 하나 선택해 주세요.\n후보 질문 목록:\n${candidates
+    .map((q, i) => `${i + 1}. ${q}`)
+    .join("\n")}\n답변으로 이미 다룬 주제는 피하고, 질문 문장만 한국어로 출력하세요.`;
+
+  try {
+    const result = await genAI.models.generateContent({
+      model: "gemini-2.5-flash",
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
+    });
+    const text = result.text?.trim();
+    if (text) return text;
+  } catch (e) {
+    console.error("generateSecondQuestion error", e);
+  }
+  return candidates[0];
+}

--- a/src/lib/interview/questionCache.ts
+++ b/src/lib/interview/questionCache.ts
@@ -1,0 +1,13 @@
+const cache = new Map<number, string>();
+
+export function getCachedQuestion(sessionId: number) {
+  return cache.get(sessionId);
+}
+
+export function setCachedQuestion(sessionId: number, question: string) {
+  cache.set(sessionId, question);
+}
+
+export function clearCachedQuestion(sessionId: number) {
+  cache.delete(sessionId);
+}


### PR DESCRIPTION
## Summary
- start session with fixed self-introduction question
- pre-generate upcoming interview questions with cache and Gemini
- add selectable second question from predefined candidates

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac3d381dd88321a0aa40c2213957f2