### PR TITLE
feat: add Dockerfile for Node build and runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json .
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["npm","start"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile using Node 20 for build and runtime

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68c110b391648321b5400b634837630f