### PR TITLE
chore: add Docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Dependencies
+node_modules
+.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# Next.js build output
+.next
+out
+
+# Prisma
+prisma/migrations
+
+# Logs
+*.log
+
+# Version control
+.git
+.github
+
+# Environment files
+.env*
+.vercel
+
+# Development artifacts
+.DS_Store
+*.pem
+.vscode
+.idea
+coverage
+build
+*.tsbuildinfo
+next-env.d.ts
+src/generated/prisma


### PR DESCRIPTION
## Summary
- add `.dockerignore` to exclude development artifacts and version control files from Docker builds

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any / unused vars)


------
https://chatgpt.com/codex/tasks/task_e_68c112d7d6f88321a98b3da86550d43b