### PR TITLE
Add entrypoint script and Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+npx prisma migrate deploy
+
+if [ -n "$RUN_DB_SEED" ]; then
+  npm run db:seed
+fi
+
+exec npm start


### PR DESCRIPTION
## Summary
- add entrypoint script to run Prisma migrations, optional seeding, then start
- introduce Dockerfile with entrypoint setup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68c116ff50a48321a5b8ef56ebff133e