### PR TITLE
Add Swagger API documentation and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ npm start
 npm run lint
 ```
 
-### 8. Docker Compose 실행
+### 8. API 문서 (Swagger)
+
+API 스키마는 `/api/swagger` 엔드포인트에서 OpenAPI 3.1 JSON으로 제공됩니다. 브라우저에서 상호작용형 문서를 확인하려면 개발 서버를 실행한 뒤 <http://localhost:3000/api-docs>로 접속하세요.
+
+### 9. Docker Compose 실행
 Docker와 Docker Compose가 설치되어 있다면 다음 명령으로 애플리케이션과 PostgreSQL을 컨테이너로 실행할 수 있습니다.
 ```bash
 docker-compose up -d

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect } from "react";
+
+type SwaggerUIBundle = {
+  (config: {
+    url: string;
+    dom_id: string;
+    presets: unknown[];
+    layout: string;
+    docExpansion: string;
+    defaultModelsExpandDepth: number;
+  }): void;
+  presets?: {
+    apis: unknown;
+  };
+};
+
+declare global {
+  interface Window {
+    SwaggerUIBundle?: SwaggerUIBundle;
+  }
+}
+
+const SWAGGER_CSS_ID = "swagger-ui-css";
+const SWAGGER_SCRIPT_ID = "swagger-ui-script";
+
+export default function ApiDocsPage() {
+  useEffect(() => {
+    if (!document.getElementById(SWAGGER_CSS_ID)) {
+      const link = document.createElement("link");
+      link.id = SWAGGER_CSS_ID;
+      link.rel = "stylesheet";
+      link.href = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css";
+      document.head.appendChild(link);
+    }
+
+    const initializeSwagger = () => {
+      if (!window.SwaggerUIBundle) return;
+      const apisPreset = window.SwaggerUIBundle.presets?.apis;
+      window.SwaggerUIBundle({
+        url: "/api/swagger",
+        dom_id: "#swagger-ui",
+        presets: apisPreset ? [apisPreset] : [],
+        layout: "BaseLayout",
+        docExpansion: "none",
+        defaultModelsExpandDepth: -1,
+      });
+    };
+
+    const existingScript = document.getElementById(
+      SWAGGER_SCRIPT_ID
+    ) as HTMLScriptElement | null;
+
+    if (window.SwaggerUIBundle) {
+      initializeSwagger();
+      return;
+    }
+
+    const script =
+      existingScript ?? document.createElement("script");
+
+    if (!existingScript) {
+      script.id = SWAGGER_SCRIPT_ID;
+      script.src =
+        "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js";
+      script.async = true;
+      document.body.appendChild(script);
+    }
+
+    script.addEventListener("load", initializeSwagger);
+
+    return () => {
+      script.removeEventListener("load", initializeSwagger);
+      const uiRoot = document.getElementById("swagger-ui");
+      if (uiRoot) {
+        uiRoot.innerHTML = "";
+      }
+    };
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-white px-4 py-6">
+      <div className="mx-auto max-w-6xl">
+        <h1 className="mb-4 text-3xl font-semibold text-gray-900">
+          VocAI API 문서
+        </h1>
+        <p className="mb-6 text-gray-600">
+          아래에서 OpenAPI 사양과 상호작용하며 API를 테스트할 수 있습니다.
+        </p>
+        <div id="swagger-ui" className="bg-white shadow-sm" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/swagger/route.ts
+++ b/src/app/api/swagger/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import swaggerDocument from "@/lib/swagger";
+
+export const dynamic = "force-static";
+
+export async function GET() {
+  return NextResponse.json(swaggerDocument);
+}

--- a/src/app/api/user/me/route.ts
+++ b/src/app/api/user/me/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import jwt from 'jsonwebtoken';
+import { verifyJwt } from '@/lib/verifyJwt';
 
 export async function GET(req: NextRequest) {
   // 1. 쿠키에서 token 읽기
@@ -9,10 +9,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: '토큰 필요' }, { status: 401 });
   }
 
-  let decoded: any;
-  try {
-    decoded = jwt.verify(token, process.env.JWT_SECRET!);
-  } catch {
+  const decoded = verifyJwt(token);
+  if (!decoded) {
     return NextResponse.json({ error: '유효하지 않은 토큰' }, { status: 401 });
   }
 
@@ -53,10 +51,8 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: '토큰 필요' }, { status: 401 });
   }
 
-  let decoded: any;
-  try {
-    decoded = jwt.verify(token, process.env.JWT_SECRET!);
-  } catch {
+  const decoded = verifyJwt(token);
+  if (!decoded) {
     return NextResponse.json({ error: '유효하지 않은 토큰' }, { status: 401 });
   }
 
@@ -84,7 +80,7 @@ export async function PATCH(req: NextRequest) {
     });
 
     return NextResponse.json({ success: true });
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: '업데이트 실패' }, { status: 500 });
   }
 }

--- a/src/app/api/user/posts/route.ts
+++ b/src/app/api/user/posts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import jwt from 'jsonwebtoken';
+import { verifyJwt } from '@/lib/verifyJwt';
 
 export async function GET(req: NextRequest) {
   // 1. 토큰에서 userId 추출
@@ -9,10 +9,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: '토큰 필요' }, { status: 401 });
   }
 
-  let decoded: any;
-  try {
-    decoded = jwt.verify(token, process.env.JWT_SECRET!);
-  } catch {
+  const decoded = verifyJwt(token);
+  if (!decoded) {
     return NextResponse.json({ error: '유효하지 않은 토큰' }, { status: 401 });
   }
 

--- a/src/app/mypage/profile/edit/page.tsx
+++ b/src/app/mypage/profile/edit/page.tsx
@@ -2,36 +2,18 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { userAPI } from '@/lib/api';
-import { authAPI } from '@/lib/api';
+import { userAPI, authAPI } from '@/lib/api';
+import type { PersonaData, UserProfileResponse } from '@/lib/api';
 import { HiUser, HiPencilSquare } from 'react-icons/hi2';
 import { companies } from '@/lib/constants/boards';
 import { TECH_STACKS, JOB_ROLES } from '@/lib/constants/persona';
-
-type Persona = {
-  company: string[];
-  job: string[];
-  careerLevel: string;
-  difficulty: '쉬움' | '중간' | '어려움';
-  techStack: string[];
-};
 
 interface UserProfile {
   email?: string;
   name?: string;
   nickName?: string;
   phone?: string;
-  persona?: Persona;
-}
-
-interface GetMeResponse {
-  email: string;
-  profile?: {
-    name?: string;
-    nickName?: string;
-    phoneNum?: string;
-    persona?: Persona;
-  };
+  persona?: PersonaData;
 }
 
 export default function EditProfilePage() {
@@ -66,13 +48,14 @@ export default function EditProfilePage() {
   useEffect(() => {
     const fetchProfile = async () => {
       try {
-        const res = await userAPI.getMe() as { data: GetMeResponse };
+        const res = await userAPI.getMe();
+        const profileData: UserProfileResponse['profile'] = res.data.profile;
         setProfile({
           email: res.data.email,
-          name: res.data.profile?.name ?? '',
-          nickName: res.data.profile?.nickName ?? '',
-          phone: res.data.profile?.phoneNum ?? '',
-          persona: res.data.profile?.persona ?? {
+          name: profileData.name ?? '',
+          nickName: profileData.nickName ?? '',
+          phone: profileData.phoneNum ?? '',
+          persona: profileData.persona ?? {
             company: [],
             job: [],
             careerLevel: '',
@@ -81,15 +64,15 @@ export default function EditProfilePage() {
           },
         });
         setForm({
-          name: res.data.profile?.name ?? '',
-          nickName: res.data.profile?.nickName ?? '',
-          phone: res.data.profile?.phoneNum ?? '',
+          name: profileData.name ?? '',
+          nickName: profileData.nickName ?? '',
+          phone: profileData.phoneNum ?? '',
           persona: {
-            company: res.data.profile?.persona?.company ?? [],
-            job: res.data.profile?.persona?.job ?? [],
-            careerLevel: res.data.profile?.persona?.careerLevel ?? '',
-            difficulty: res.data.profile?.persona?.difficulty ?? '쉬움',
-            techStack: res.data.profile?.persona?.techStack ?? [],
+            company: profileData.persona?.company ?? [],
+            job: profileData.persona?.job ?? [],
+            careerLevel: profileData.persona?.careerLevel ?? '',
+            difficulty: profileData.persona?.difficulty ?? '쉬움',
+            techStack: profileData.persona?.techStack ?? [],
           },
         });
       } catch {
@@ -104,7 +87,7 @@ export default function EditProfilePage() {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     if (name.startsWith('persona.')) {
-      const key = name.replace('persona.', '') as keyof Persona;
+      const key = name.replace('persona.', '') as keyof PersonaData;
       setForm(prev => ({
         ...prev,
         persona: {

--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -3,22 +3,15 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { userAPI } from '@/lib/api';
+import type { PersonaData, UserProfileResponse } from '@/lib/api';
 import { HiUser, HiPencilSquare } from 'react-icons/hi2';
-
-type Persona = {
-  company: string;
-  job: string;
-  careerLevel: string;
-  difficulty: '쉬움' | '중간' | '어려움';
-  techStack: string[];
-};
 
 interface UserProfile {
   email?: string;
   name?: string;
   nickName?: string;
   phone?: string;
-  persona?: Persona;
+  persona?: PersonaData | null;
 }
 
 export default function MyProfilePage() {
@@ -29,13 +22,14 @@ export default function MyProfilePage() {
   useEffect(() => {
     const fetchProfile = async () => {
       try {
-        const res = await userAPI.getMe() as { data: { email: string; profile?: any } };
+        const res = await userAPI.getMe();
+        const profileData: UserProfileResponse['profile'] = res.data.profile;
         setProfile({
           email: res.data.email,
-          name: res.data.profile?.name ?? '',
-          nickName: res.data.profile?.nickName ?? '',
-          phone: res.data.profile?.phoneNum ?? '',
-          persona: res.data.profile?.persona ?? undefined,
+          name: profileData.name ?? '',
+          nickName: profileData.nickName ?? '',
+          phone: profileData.phoneNum ?? '',
+          persona: profileData.persona ?? null,
         });
       } catch {
         setProfile(null);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,6 +38,27 @@ export interface SigninData {
   password: string;
 }
 
+export interface PersonaData {
+  company: string[];
+  job: string[];
+  careerLevel: string;
+  difficulty: '쉬움' | '중간' | '어려움';
+  techStack: string[];
+}
+
+export interface UserProfileResponse {
+  userId: number;
+  email: string;
+  createdAt: string;
+  profile: {
+    profileId: number;
+    name: string;
+    nickName: string;
+    phoneNum: string;
+    persona: PersonaData | null;
+  };
+}
+
 // 중복확인 응답 타입
 export interface DuplicateCheckResponse {
   available: boolean;
@@ -259,14 +280,19 @@ export const userAPI = {
     return apiClient.get('/user/profile');
   },
   getMe: async () => {
-    return apiClient.get('/user/me');
+    return apiClient.get<UserProfileResponse>('/user/me');
   },
-  updateMe: async (data: { name: string; nickName: string; phone: string, persona: any }) => {
+  updateMe: async (data: {
+    name: string;
+    nickName: string;
+    phone: string;
+    persona?: PersonaData | null;
+  }) => {
     return apiClient.patch('/user/me', {
       name: data.name,
       nickName: data.nickName,
       phone: data.phone.replace(/\D/g, ''),
-      persona: data.persona,
+      persona: data.persona ?? null,
     });
   },
   // 내가 쓴 게시글 목록 조회

--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -1,0 +1,2072 @@
+const swaggerDocument = {
+  openapi: "3.1.0",
+  info: {
+    title: "VocAI API",
+    version: "1.0.0",
+    description:
+      "VocAI 애플리케이션의 REST API를 문서화한 OpenAPI 명세입니다. 쿠키 기반 JWT 인증을 사용하는 보호된 엔드포인트를 포함합니다.",
+  },
+  servers: [
+    {
+      url: "http://localhost:3000",
+      description: "로컬 개발 서버",
+    },
+  ],
+  tags: [
+    { name: "Auth", description: "사용자 인증 및 계정 관리" },
+    { name: "Users", description: "사용자 프로필 및 개인화" },
+    { name: "Persona", description: "면접 페르소나 관리" },
+    { name: "Boards", description: "게시판 및 게시글" },
+    { name: "Comments", description: "댓글 관리" },
+    { name: "Attachments", description: "첨부파일 다운로드" },
+    { name: "AI Interview", description: "AI 모의 면접 흐름" },
+    { name: "TTS", description: "음성 합성" },
+  ],
+  components: {
+    securitySchemes: {
+      cookieAuth: {
+        type: "apiKey",
+        in: "cookie",
+        name: "token",
+        description:
+          "`/api/auth/signin`으로 발급되는 JWT 토큰. 대부분의 보호된 API는 이 쿠키가 필요합니다.",
+      },
+    },
+    schemas: {
+      ErrorResponse: {
+        type: "object",
+        properties: {
+          error: {
+            type: "string",
+            description: "오류 메시지",
+          },
+        },
+        required: ["error"],
+      },
+      MessageResponse: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      SuccessResponse: {
+        type: "object",
+        properties: {
+          success: { type: "boolean" },
+        },
+        required: ["success"],
+      },
+      AvailabilityResponse: {
+        type: "object",
+        properties: {
+          available: { type: "boolean" },
+          message: { type: "string" },
+        },
+        required: ["available", "message"],
+      },
+      SignupRequest: {
+        type: "object",
+        properties: {
+          email: {
+            type: "string",
+            format: "email",
+          },
+          password: {
+            type: "string",
+            minLength: 8,
+          },
+          name: {
+            type: "string",
+          },
+          nickname: {
+            type: "string",
+          },
+          phone: {
+            type: "string",
+            description: "하이픈이 제거된 전화번호 문자열",
+          },
+        },
+        required: ["email", "password", "name", "nickname", "phone"],
+      },
+      SignupResponse: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+          user: {
+            type: "object",
+            properties: {
+              email: { type: "string", format: "email" },
+              nickname: { type: "string" },
+            },
+            required: ["email", "nickname"],
+          },
+        },
+        required: ["message", "user"],
+      },
+      SigninRequest: {
+        type: "object",
+        properties: {
+          email: { type: "string", format: "email" },
+          password: { type: "string" },
+        },
+        required: ["email", "password"],
+      },
+      SigninResponse: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+          token: {
+            type: "string",
+            description: "`token` 쿠키에도 저장되는 JWT 토큰",
+          },
+        },
+        required: ["message", "token"],
+      },
+      Persona: {
+        type: "object",
+        properties: {
+          company: {
+            type: "array",
+            items: { type: "string" },
+          },
+          job: {
+            type: "array",
+            items: { type: "string" },
+          },
+          careerLevel: { type: "string" },
+          difficulty: {
+            type: "string",
+            enum: ["쉬움", "중간", "어려움"],
+          },
+          techStack: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        required: [
+          "company",
+          "job",
+          "careerLevel",
+          "difficulty",
+          "techStack",
+        ],
+      },
+      ProfileSummary: {
+        type: "object",
+        properties: {
+          profileId: { type: "integer" },
+          userId: { type: "integer" },
+          nickName: { type: "string" },
+          name: { type: "string" },
+          email: { type: "string", format: "email" },
+        },
+        required: ["profileId", "userId", "nickName", "name", "email"],
+      },
+      ProfileDetail: {
+        allOf: [
+          { $ref: "#/components/schemas/ProfileSummary" },
+          {
+            type: "object",
+            properties: {
+              phoneNum: { type: "string" },
+              persona: {
+                oneOf: [
+                  { $ref: "#/components/schemas/Persona" },
+                  { type: "null" },
+                ],
+              },
+            },
+            required: ["phoneNum", "persona"],
+          },
+        ],
+      },
+      UserProfile: {
+        type: "object",
+        properties: {
+          userId: { type: "integer" },
+          email: { type: "string", format: "email" },
+          createdAt: { type: "string", format: "date-time" },
+          profile: {
+            type: "object",
+            properties: {
+              profileId: { type: "integer" },
+              name: { type: "string" },
+              nickName: { type: "string" },
+              phoneNum: { type: "string" },
+              persona: {
+                oneOf: [
+                  { $ref: "#/components/schemas/Persona" },
+                  { type: "null" },
+                ],
+              },
+            },
+            required: ["profileId", "name", "nickName", "phoneNum", "persona"],
+          },
+        },
+        required: ["userId", "email", "createdAt", "profile"],
+      },
+      UpdateProfileRequest: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          nickName: { type: "string" },
+          phone: { type: "string" },
+          persona: {
+            oneOf: [
+              { $ref: "#/components/schemas/Persona" },
+              { type: "null" },
+            ],
+          },
+        },
+        required: ["name", "nickName", "phone"],
+      },
+      CommentProfile: {
+        allOf: [
+          { $ref: "#/components/schemas/ProfileSummary" },
+          {
+            type: "object",
+            properties: {
+              phoneNum: { type: "string" },
+              persona: {
+                oneOf: [
+                  { $ref: "#/components/schemas/Persona" },
+                  { type: "null" },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      Comment: {
+        type: "object",
+        properties: {
+          commentId: { type: "integer" },
+          postId: { type: "integer" },
+          profileId: { type: "integer" },
+          nickName: { type: "string" },
+          content: { type: "string" },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+          deletedAt: {
+            oneOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+          },
+          profile: { $ref: "#/components/schemas/CommentProfile" },
+        },
+        required: [
+          "commentId",
+          "postId",
+          "profileId",
+          "nickName",
+          "content",
+          "createdAt",
+          "updatedAt",
+          "deletedAt",
+          "profile",
+        ],
+      },
+      CommentRequest: {
+        type: "object",
+        properties: {
+          postId: { type: "integer" },
+          content: { type: "string" },
+        },
+        required: ["postId", "content"],
+      },
+      CommentUpdateRequest: {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+      },
+      CommentDeleteResponse: {
+        type: "object",
+        properties: {
+          success: { type: "boolean" },
+          deletedCommentId: { type: "integer" },
+        },
+        required: ["success", "deletedCommentId"],
+      },
+      BoardStat: {
+        type: "object",
+        properties: {
+          boardId: { type: "integer" },
+          name: { type: "string" },
+          postCount: { type: "integer" },
+        },
+        required: ["boardId", "name", "postCount"],
+      },
+      BoardStatsResponse: {
+        type: "object",
+        properties: {
+          stats: {
+            type: "array",
+            items: { $ref: "#/components/schemas/BoardStat" },
+          },
+        },
+        required: ["stats"],
+      },
+      AttachmentRequest: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          size: { type: "integer" },
+          type: { type: "string" },
+          data: {
+            type: "string",
+            description: "Base64 인코딩된 파일 데이터",
+          },
+        },
+        required: ["name", "size", "type", "data"],
+      },
+      AttachmentMetadata: {
+        type: "object",
+        properties: {
+          attachmentId: { type: "string" },
+          fileName: { type: "string" },
+          fileSize: { type: "integer" },
+          fileType: { type: "string" },
+          createdAt: { type: "string", format: "date-time" },
+        },
+        required: [
+          "attachmentId",
+          "fileName",
+          "fileSize",
+          "fileType",
+          "createdAt",
+        ],
+      },
+      Attachment: {
+        allOf: [
+          { $ref: "#/components/schemas/AttachmentMetadata" },
+          {
+            type: "object",
+            properties: {
+              fileData: {
+                type: "string",
+                description: "Base64 인코딩된 파일 데이터",
+              },
+              postId: { type: "integer" },
+            },
+            required: ["fileData", "postId"],
+          },
+        ],
+      },
+      BoardSummary: {
+        type: "object",
+        properties: {
+          boardId: { type: "integer" },
+          name: { type: "string" },
+          isActive: { type: "boolean" },
+        },
+        required: ["boardId", "name", "isActive"],
+      },
+      BoardPost: {
+        type: "object",
+        properties: {
+          postId: { type: "integer" },
+          profileId: { type: "integer" },
+          boardId: { type: "integer" },
+          nickName: { type: "string" },
+          title: { type: "string" },
+          content: { type: "string" },
+          view: { type: "integer" },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+          deletedAt: {
+            oneOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+          },
+          company: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          jobCategory: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          tags: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+            description: "콤마로 구분된 태그 문자열",
+          },
+        },
+        required: [
+          "postId",
+          "profileId",
+          "boardId",
+          "nickName",
+          "title",
+          "content",
+          "view",
+          "createdAt",
+          "updatedAt",
+          "deletedAt",
+          "company",
+          "jobCategory",
+          "tags",
+        ],
+      },
+      BoardPostListItem: {
+        allOf: [
+          { $ref: "#/components/schemas/BoardPost" },
+          {
+            type: "object",
+            properties: {
+              profile: { $ref: "#/components/schemas/CommentProfile" },
+              board: { $ref: "#/components/schemas/BoardSummary" },
+              attachments: {
+                type: "array",
+                items: { $ref: "#/components/schemas/AttachmentMetadata" },
+              },
+              commentCount: { type: "integer" },
+            },
+            required: ["profile", "board", "attachments", "commentCount"],
+          },
+        ],
+      },
+      BoardPostDetail: {
+        allOf: [
+          { $ref: "#/components/schemas/BoardPost" },
+          {
+            type: "object",
+            properties: {
+              profile: { $ref: "#/components/schemas/CommentProfile" },
+              board: { $ref: "#/components/schemas/BoardSummary" },
+              attachments: {
+                type: "array",
+                items: { $ref: "#/components/schemas/Attachment" },
+              },
+              comments: {
+                type: "array",
+                items: { $ref: "#/components/schemas/Comment" },
+              },
+              commentCount: { type: "integer" },
+            },
+            required: [
+              "profile",
+              "board",
+              "attachments",
+              "comments",
+              "commentCount",
+            ],
+          },
+        ],
+      },
+      CreatePostRequest: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          content: { type: "string" },
+          attachments: {
+            type: "array",
+            items: { $ref: "#/components/schemas/AttachmentRequest" },
+          },
+          company: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          jobCategory: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          tags: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        required: ["title", "content"],
+      },
+      CreatePostResponse: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+          post: { $ref: "#/components/schemas/BoardPost" },
+          attachmentsCount: { type: "integer" },
+          receivedData: {
+            type: "object",
+            properties: {
+              titleLength: { type: "integer" },
+              contentLength: { type: "integer" },
+              boardId: { type: "integer" },
+              hasAttachments: { type: "boolean" },
+              attachmentNames: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+            required: [
+              "titleLength",
+              "contentLength",
+              "boardId",
+              "hasAttachments",
+              "attachmentNames",
+            ],
+          },
+        },
+        required: [
+          "message",
+          "post",
+          "attachmentsCount",
+          "receivedData",
+        ],
+      },
+      UpdatePostRequest: {
+        allOf: [
+          { $ref: "#/components/schemas/CreatePostRequest" },
+          {
+            type: "object",
+            properties: {
+              deleteAttachmentIndexes: {
+                type: "array",
+                items: { type: "integer" },
+              },
+            },
+          },
+        ],
+      },
+      UpdatePostResponse: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+          post: { $ref: "#/components/schemas/BoardPost" },
+          deletedCount: { type: "integer" },
+          addedCount: { type: "integer" },
+        },
+        required: ["message", "post", "deletedCount", "addedCount"],
+      },
+      DeletePostResponse: {
+        type: "object",
+        properties: {
+          success: { type: "boolean" },
+          deletedPostId: { type: "integer" },
+        },
+        required: ["success", "deletedPostId"],
+      },
+      PostsResponse: {
+        type: "object",
+        properties: {
+          posts: {
+            type: "array",
+            items: { $ref: "#/components/schemas/BoardPost" },
+          },
+        },
+        required: ["posts"],
+      },
+      MockInterviewSession: {
+        type: "object",
+        properties: {
+          sessionId: { type: "integer" },
+          createdAt: { type: "string", format: "date-time" },
+          title: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+        },
+        required: ["sessionId", "createdAt", "title"],
+      },
+      MockInterviewRecord: {
+        type: "object",
+        properties: {
+          interviewId: { type: "integer" },
+          sessionId: { type: "integer" },
+          question: { type: "string" },
+          answerText: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          summary: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          feedback: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          createdAt: { type: "string", format: "date-time" },
+          deletedAt: {
+            oneOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+          },
+        },
+        required: [
+          "interviewId",
+          "sessionId",
+          "question",
+          "answerText",
+          "summary",
+          "feedback",
+          "createdAt",
+          "deletedAt",
+        ],
+      },
+      MockInterviewSessionDetail: {
+        type: "object",
+        properties: {
+          records: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                question: { type: "string" },
+                answerText: {
+                  oneOf: [{ type: "string" }, { type: "null" }],
+                },
+                summary: {
+                  oneOf: [{ type: "string" }, { type: "null" }],
+                },
+                feedback: {
+                  oneOf: [{ type: "string" }, { type: "null" }],
+                },
+              },
+              required: ["question", "answerText", "summary", "feedback"],
+            },
+          },
+          ended: { type: "boolean" },
+          summary: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+          feedback: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+        },
+        required: ["records", "ended", "summary", "feedback"],
+      },
+      MockInterviewProgressResponse: {
+        type: "object",
+        properties: {
+          question: { type: "string" },
+          summary: { type: "string" },
+          feedback: { type: "string" },
+          record: { $ref: "#/components/schemas/MockInterviewRecord" },
+        },
+        required: ["question"],
+        description:
+          "`answerText`를 제공한 경우에는 summary/feedback/record가 포함되고, 없는 경우에는 다음 질문만 반환됩니다.",
+      },
+      MockInterviewQuestionResponse: {
+        type: "object",
+        properties: {
+          question: { type: "string" },
+          recordId: { type: "integer" },
+        },
+        required: ["question", "recordId"],
+      },
+      MockInterviewAnswerRequest: {
+        type: "object",
+        properties: {
+          answerText: { type: "string" },
+        },
+        required: ["answerText"],
+      },
+      MockInterviewAnswerResponse: {
+        type: "object",
+        properties: {
+          summary: { type: "string" },
+          feedback: { type: "string" },
+          record: { $ref: "#/components/schemas/MockInterviewRecord" },
+        },
+        required: ["summary", "feedback", "record"],
+      },
+      TranscriptionResponse: {
+        type: "object",
+        properties: {
+          transcribedText: { type: "string" },
+        },
+        required: ["transcribedText"],
+      },
+      TTSRequest: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+        },
+        required: ["text"],
+      },
+    },
+  },
+  paths: {
+    "/api/auth/signup": {
+      post: {
+        tags: ["Auth"],
+        summary: "이메일과 비밀번호로 회원 가입",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/SignupRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "회원가입 성공",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SignupResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "유효성 오류 또는 중복 계정",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/auth/signin": {
+      post: {
+        tags: ["Auth"],
+        summary: "이메일/비밀번호 로그인",
+        description:
+          "성공 시 응답 본문과 `token` HttpOnly 쿠키에 JWT가 포함됩니다.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/SigninRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "로그인 성공",
+            headers: {
+              "Set-Cookie": {
+                schema: { type: "string" },
+                description: "HttpOnly JWT 토큰 쿠키",
+              },
+            },
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SigninResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "잘못된 자격 증명",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/auth/signout": {
+      post: {
+        tags: ["Auth"],
+        summary: "로그아웃",
+        responses: {
+          "200": {
+            description: "로그아웃 성공",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/MessageResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/auth/check-email": {
+      get: {
+        tags: ["Auth"],
+        summary: "이메일 중복 확인",
+        parameters: [
+          {
+            name: "email",
+            in: "query",
+            required: true,
+            schema: { type: "string", format: "email" },
+            description: "중복 여부를 확인할 이메일",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "중복 여부",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/AvailabilityResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/auth/check-nickname": {
+      get: {
+        tags: ["Auth"],
+        summary: "닉네임 중복 확인",
+        parameters: [
+          {
+            name: "nickname",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+            description: "중복 여부를 확인할 닉네임",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "중복 여부",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/AvailabilityResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/user/me": {
+      get: {
+        tags: ["Users"],
+        summary: "로그인한 사용자 정보 조회",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "사용자 정보",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/UserProfile" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "404": {
+            description: "사용자 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      patch: {
+        tags: ["Users"],
+        summary: "사용자 프로필 수정",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdateProfileRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "수정 완료",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SuccessResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "업데이트 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/user/profile": {
+      get: {
+        tags: ["Users"],
+        summary: "로그인한 사용자의 기본 프로필",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "프로필 정보",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ProfileSummary" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/user/posts": {
+      get: {
+        tags: ["Users"],
+        summary: "내가 작성한 게시글 조회",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "게시글 목록",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    posts: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/BoardPost" },
+                    },
+                  },
+                  required: ["posts"],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "404": {
+            description: "프로필 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/persona": {
+      get: {
+        tags: ["Persona"],
+        summary: "저장된 면접 페르소나 조회",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "페르소나 정보 또는 null",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/Persona" },
+                    { type: "null" },
+                  ],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["Persona"],
+        summary: "면접 페르소나 저장",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Persona" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "저장된 페르소나",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Persona" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/comments": {
+      get: {
+        tags: ["Comments"],
+        summary: "게시글의 댓글 조회",
+        parameters: [
+          {
+            name: "postId",
+            in: "query",
+            required: true,
+            schema: { type: "integer" },
+            description: "대상 게시글 ID",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "댓글 목록",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Comment" },
+                },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["Comments"],
+        summary: "댓글 작성",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CommentRequest" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "생성된 댓글",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Comment" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/comments/{commentId}": {
+      parameters: [
+        {
+          name: "commentId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      get: {
+        tags: ["Comments"],
+        summary: "댓글 단건 조회",
+        responses: {
+          "200": {
+            description: "댓글 정보",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/Comment" },
+                    {
+                      type: "object",
+                      properties: {
+                        post: { $ref: "#/components/schemas/BoardPost" },
+                      },
+                      required: ["post"],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "404": {
+            description: "댓글 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      put: {
+        tags: ["Comments"],
+        summary: "댓글 수정",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CommentUpdateRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "수정된 댓글",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Comment" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      delete: {
+        tags: ["Comments"],
+        summary: "댓글 삭제",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "삭제 결과",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CommentDeleteResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/boards/stats": {
+      get: {
+        tags: ["Boards"],
+        summary: "게시판별 게시글 수",
+        responses: {
+          "200": {
+            description: "게시판 통계",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/BoardStatsResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/boards/{boardId}/posts": {
+      parameters: [
+        {
+          name: "boardId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      get: {
+        tags: ["Boards"],
+        summary: "게시판 게시글 목록",
+        responses: {
+          "200": {
+            description: "게시글 목록",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    posts: {
+                      type: "array",
+                      items: {
+                        $ref: "#/components/schemas/BoardPostListItem",
+                      },
+                    },
+                  },
+                  required: ["posts"],
+                },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 게시판 ID",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["Boards"],
+        summary: "게시글 작성",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreatePostRequest" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "생성된 게시글",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CreatePostResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "유효하지 않은 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/boards/{boardId}/posts/{postId}": {
+      parameters: [
+        {
+          name: "boardId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+        {
+          name: "postId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      get: {
+        tags: ["Boards"],
+        summary: "게시글 상세",
+        responses: {
+          "200": {
+            description: "게시글 상세 정보",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/BoardPostDetail" },
+              },
+            },
+          },
+          "404": {
+            description: "게시글 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      put: {
+        tags: ["Boards"],
+        summary: "게시글 수정",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdatePostRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "수정 결과",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/UpdatePostResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      delete: {
+        tags: ["Boards"],
+        summary: "게시글 삭제",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "삭제 결과",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/DeletePostResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/boards/{boardId}/posts/{postId}/increment-view": {
+      parameters: [
+        {
+          name: "boardId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+        {
+          name: "postId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      post: {
+        tags: ["Boards"],
+        summary: "게시글 조회수 증가",
+        responses: {
+          "200": {
+            description: "증가 결과",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/MessageResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 게시글 ID",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/boards/{boardId}/search": {
+      parameters: [
+        {
+          name: "boardId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+        {
+          name: "keyword",
+          in: "query",
+          required: false,
+          schema: { type: "string" },
+          description: "제목/본문 검색 키워드",
+        },
+      ],
+      get: {
+        tags: ["Boards"],
+        summary: "게시글 검색",
+        responses: {
+          "200": {
+            description: "검색 결과",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/PostsResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/attachments/{attachmentId}": {
+      parameters: [
+        {
+          name: "attachmentId",
+          in: "path",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+      get: {
+        tags: ["Attachments"],
+        summary: "첨부파일 다운로드",
+        responses: {
+          "200": {
+            description: "파일 스트림",
+            content: {
+              "application/octet-stream": {
+                schema: {
+                  type: "string",
+                  format: "binary",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "404": {
+            description: "파일 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/AIInterview": {
+      get: {
+        tags: ["AI Interview"],
+        summary: "내 면접 세션 목록",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "세션 목록",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/MockInterviewSession" },
+                },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/AIInterview/start": {
+      post: {
+        tags: ["AI Interview"],
+        summary: "새 면접 세션 시작",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "201": {
+            description: "생성된 세션과 첫 질문",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    sessionId: { type: "integer" },
+                    question: { type: "string" },
+                  },
+                  required: ["sessionId", "question"],
+                },
+              },
+            },
+          },
+          "400": {
+            description: "페르소나 미설정 등",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/AIInterview/end": {
+      post: {
+        tags: ["AI Interview"],
+        summary: "면접 세션 종료 및 요약 생성",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  sessionId: { type: "integer" },
+                },
+                required: ["sessionId"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "세션 요약 및 피드백",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    summary: { type: "string" },
+                    feedback: { type: "string" },
+                  },
+                  required: ["summary", "feedback"],
+                },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/AIInterview/{sessionId}": {
+      parameters: [
+        {
+          name: "sessionId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      get: {
+        tags: ["AI Interview"],
+        summary: "세션 상세 기록 조회",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "세션 기록",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/MockInterviewSessionDetail" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["AI Interview"],
+        summary: "답변 저장 후 다음 질문 요청",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  answerText: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "다음 질문 또는 저장 결과",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/MockInterviewProgressResponse",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      patch: {
+        tags: ["AI Interview"],
+        summary: "세션 제목 수정",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  title: { type: "string" },
+                },
+                required: ["title"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "수정된 제목",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    title: { type: "string" },
+                  },
+                  required: ["title"],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+      delete: {
+        tags: ["AI Interview"],
+        summary: "세션 삭제",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "삭제 결과",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SuccessResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "인증 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "권한 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/AIInterview/{sessionId}/question": {
+      parameters: [
+        {
+          name: "sessionId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      post: {
+        tags: ["AI Interview"],
+        summary: "새 질문 생성",
+        security: [{ cookieAuth: [] }],
+        responses: {
+          "200": {
+            description: "생성된 질문",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/MockInterviewQuestionResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 세션 ID",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/AIInterview/{sessionId}/answer": {
+      parameters: [
+        {
+          name: "sessionId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      post: {
+        tags: ["AI Interview"],
+        summary: "가장 최근 질문에 대한 답변 저장",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/MockInterviewAnswerRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "요약 및 피드백",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/MockInterviewAnswerResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "404": {
+            description: "답변할 질문 없음",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/AIInterview/{sessionId}/record": {
+      parameters: [
+        {
+          name: "sessionId",
+          in: "path",
+          required: true,
+          schema: { type: "integer" },
+        },
+      ],
+      post: {
+        tags: ["AI Interview"],
+        summary: "음성 답변 업로드 및 전사",
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "multipart/form-data": {
+              schema: {
+                type: "object",
+                properties: {
+                  file: {
+                    type: "string",
+                    format: "binary",
+                    description: "브라우저에서 녹음한 음성 파일",
+                  },
+                },
+                required: ["file"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "전사된 텍스트",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TranscriptionResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "잘못된 요청",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "전사 실패",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/tts": {
+      post: {
+        tags: ["TTS"],
+        summary: "텍스트를 음성으로 변환",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/TTSRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "생성된 음성",
+            content: {
+              "audio/mpeg": {
+                schema: {
+                  type: "string",
+                  format: "binary",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "TTS 오류",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorResponse" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export default swaggerDocument;


### PR DESCRIPTION
## Summary
- add an OpenAPI 3.1 specification for existing endpoints and expose it through a new `/api/swagger` route
- provide an `/api-docs` page that loads Swagger UI to explore the API schema and note the docs entry point in the README
- reuse the shared JWT verifier and add strong persona typings in user profile flows to remove lingering `any` usage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8fa64dc1c8325ac02b7b60c0726ce